### PR TITLE
Accommodate RcppArmadillo 14.4.0-0

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 
-[![CRAN status](http://www.r-pkg.org/badges/version/PAGFL)](https://cran.r-project.org/package=PAGFL) [![CRAN_Downloads_Badge](https://cranlogs.r-pkg.org/badges/grand-total/PAGFL)](https://cran.r-project.org/package=PAGFL) [![License_GPLv3_Badge](https://img.shields.io/badge/License-GPLv3-yellow.svg)](https://www.gnu.org/licenses/gpl-3.0.html) [![R-CMD-check](https://github.com/Paul-Haimerl/PAGFL/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Paul-Haimerl/PAGFL/actions/workflows/R-CMD-check.yaml) [![codecov](https://codecov.io/gh/Paul-Haimerl/PAGFL/graph/badge.svg?token=22WHU5SU63)](https://app.codecov.io/gh/Paul-Haimerl/PAGFL)
+[![CRAN status](https://www.r-pkg.org/badges/version/PAGFL)](https://cran.r-project.org/package=PAGFL) [![CRAN_Downloads_Badge](https://cranlogs.r-pkg.org/badges/grand-total/PAGFL)](https://cran.r-project.org/package=PAGFL) [![License_GPLv3_Badge](https://img.shields.io/badge/License-GPLv3-yellow.svg)](https://www.gnu.org/licenses/gpl-3.0.html) [![R-CMD-check](https://github.com/Paul-Haimerl/PAGFL/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Paul-Haimerl/PAGFL/actions/workflows/R-CMD-check.yaml) [![codecov](https://codecov.io/gh/Paul-Haimerl/PAGFL/graph/badge.svg?token=22WHU5SU63)](https://app.codecov.io/gh/Paul-Haimerl/PAGFL)
 
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!-- badges: start -->
 
 [![CRAN
-status](http://www.r-pkg.org/badges/version/PAGFL)](https://cran.r-project.org/package=PAGFL)
+status](https://www.r-pkg.org/badges/version/PAGFL)](https://cran.r-project.org/package=PAGFL)
 [![CRAN_Downloads_Badge](https://cranlogs.r-pkg.org/badges/grand-total/PAGFL)](https://cran.r-project.org/package=PAGFL)
 [![License_GPLv3_Badge](https://img.shields.io/badge/License-GPLv3-yellow.svg)](https://www.gnu.org/licenses/gpl-3.0.html)
 [![R-CMD-check](https://github.com/Paul-Haimerl/PAGFL/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Paul-Haimerl/PAGFL/actions/workflows/R-CMD-check.yaml)

--- a/src/PAGFL-package.cpp
+++ b/src/PAGFL-package.cpp
@@ -1572,7 +1572,8 @@ arma::vec fitMeasures(unsigned int &N, const unsigned int &k, arma::vec &y, arma
     {
         y_tilde = fdIndVec(y, N, i_index);
     }
-    arma::vec ssq = sum(arma::pow(y_tilde, 2));
+    arma::vec ssq; // could also brace-initialise ssq{arma::sum(...)} 
+    ssq = arma::sum(arma::pow(y_tilde, 2));
     unsigned int n = y_tilde.n_elem;
     double r_df = n - N - k;
     double ssr = msr * n;


### PR DESCRIPTION
Dear PAGFL team,

Armadillo 14.4.0 has been released today, and Conrad and I had prepared this with the usual suite of reverse-dependency checks. A handful of packages, yours included, requires a minimal patch to compile as e.g. as_scalar now requires proper namespace scope.

This pull request is a very small change after which the package checks fine as expected. (It also fixes a minor issue with README.{md,Rmd} where one of the badges no longer shows with a http url.)

You can test it with the (GitHub and r-universe only) version 14.4.0-0 of RcppArmadillo which you can install via

```r
install.packages('RcppArmadillo', 
    repos = c('https://rcppcore.r-universe.dev',  'https://cran.r-project.org'))
```

We would like to bring the updated version to CRAN within three to four weeks so an update of your package would be greatly appreciated.  Please let us know if you have any questions; the issue is being tracked at https://github.com/RcppCore/RcppArmadillo/issues/462

Thanks!
